### PR TITLE
Fix typo

### DIFF
--- a/checkReturnValue.go
+++ b/checkReturnValue.go
@@ -108,7 +108,7 @@ func thenBranchGoodInterproceduralError() error {
 func thenBranchBadInterproceduralError() error {
 
 	if errorSource() != ErrNone {
-		// Good: returning nil despite an error
+		// Bad: returning nil despite an error
 		return getNil()
 	}
 	doSomething()


### PR DESCRIPTION
The test's function name correctly labelled it as bad, but the comment conflicted with this.